### PR TITLE
Increase speed

### DIFF
--- a/participantVisitListing.js
+++ b/participantVisitListing.js
@@ -499,10 +499,28 @@
     function participant() {
         var _this = this;
 
+        // create dictionary of id columns
+        var chart = this;
+        var newNest = d3
+            .nest()
+            .key(function(d) {
+                return d[chart.parent.settings.rendererSynced.id_col];
+            })
+            .rollup(function(d) {
+                return d;
+            })
+            .map(chart.parent.data.raw); //filtered_data?
+
+        // get all the cells
+        var cells = chart.table.selectAll('tbody tr').selectAll('td:nth-child(2)');
+
+        // Store the appropriate td cell within the first row of for each subject's nested data
+        Object.keys(newNest).map(function(objectKey, index) {
+            newNest[objectKey][0].cell = cells[index][0];
+        });
+
         this.parent.data.sets.id_col.forEach(function(id) {
-            var id_data = _this.parent.data.raw.filter(function(d) {
-                return d[_this.parent.settings.rendererSynced.id_col] === id;
-            });
+            var id_data = newNest[id];
             var id_summary = d3
                 .nest()
                 .key(function(d) {
@@ -512,16 +530,8 @@
                     return d3.format('%')(d.length / id_data.length);
                 })
                 .entries(id_data);
-            var id_cell = _this.table
-                .selectAll('tbody tr')
-                .selectAll('td:nth-child(2)')
-                .filter(function(d) {
-                    return d.text.indexOf(id) > -1;
-                }) // define a more rigid selector here
-                .filter(function(d, i) {
-                    return i === 0;
-                });
-            id_cell.attr(
+            var id_cell = newNest[id][0].cell;
+            d3.select(id_cell).attr(
                 'title',
                 id_summary
                     .map(function(status) {
@@ -1229,7 +1239,6 @@
 
     function onDestroy() {}
 
-    //import onPreprocess from './onPreprocess';
     function listing() {
         //Define listing.
         this.listing = new webCharts.createTable(

--- a/participantVisitListing.js
+++ b/participantVisitListing.js
@@ -499,8 +499,9 @@
     function participant() {
         var _this = this;
 
-        // create dictionary of id columns
         var chart = this;
+
+        // create dictionary of id columns
         var idDict = d3
             .nest()
             .key(function(d) {
@@ -514,12 +515,27 @@
         // get all the cells
         var cells = chart.table.selectAll('tbody tr').selectAll('td:nth-child(2)');
 
-        // Store the appropriate td cell within the first row of for each subject's nested data
-        Object.keys(idDict).map(function(objectKey, index) {
-            idDict[objectKey][0].cell = cells[index][0];
-        });
+        // create ditionary of table cells
+        var cellDict = d3
+            .nest()
+            .key(function(d) {
+                return d[0].__data__.text;
+            })
+            .rollup(function(d) {
+                return d[0];
+            })
+            .map(cells);
 
-        this.parent.data.sets.id_col.forEach(function(id) {
+        // get ids
+        var id_cols = d3
+            .set(
+                chart.data.filtered.map(function(d) {
+                    return d[chart.parent.settings.rendererSynced.id_col];
+                })
+            )
+            .values();
+
+        id_cols.forEach(function(id) {
             var id_data = idDict[id];
             var id_summary = d3
                 .nest()
@@ -530,8 +546,7 @@
                     return d3.format('%')(d.length / id_data.length);
                 })
                 .entries(id_data);
-            var id_cell = idDict[id][0].cell;
-            d3.select(id_cell).attr(
+            d3.select(cellDict[id][0]).attr(
                 'title',
                 id_summary
                     .map(function(status) {
@@ -1239,7 +1254,6 @@
 
     function onDestroy() {}
 
-    //import onPreprocess from './onPreprocess';
     function listing() {
         //Define listing.
         this.listing = new webCharts.createTable(

--- a/participantVisitListing.js
+++ b/participantVisitListing.js
@@ -499,21 +499,19 @@
     function participant() {
         var _this = this;
 
-        var chart = this;
-
         // create dictionary of id columns
         var idDict = d3
             .nest()
             .key(function(d) {
-                return d[chart.parent.settings.rendererSynced.id_col];
+                return d[_this.parent.settings.rendererSynced.id_col];
             })
             .rollup(function(d) {
                 return d;
             })
-            .map(chart.parent.data.raw);
+            .map(this.parent.data.raw);
 
         // get all the cells
-        var cells = chart.table.selectAll('tbody tr').selectAll('td:nth-child(2)');
+        var cells = this.table.selectAll('tbody tr').selectAll('td:nth-child(2)');
 
         // create ditionary of table cells
         var cellDict = d3
@@ -529,8 +527,8 @@
         // get ids
         var id_cols = d3
             .set(
-                chart.data.filtered.map(function(d) {
-                    return d[chart.parent.settings.rendererSynced.id_col];
+                this.data.filtered.map(function(d) {
+                    return d[_this.parent.settings.rendererSynced.id_col];
                 })
             )
             .values();
@@ -1254,6 +1252,7 @@
 
     function onDestroy() {}
 
+    //import onPreprocess from './onPreprocess';
     function listing() {
         //Define listing.
         this.listing = new webCharts.createTable(

--- a/participantVisitListing.js
+++ b/participantVisitListing.js
@@ -501,7 +501,7 @@
 
         // create dictionary of id columns
         var chart = this;
-        var newNest = d3
+        var idDict = d3
             .nest()
             .key(function(d) {
                 return d[chart.parent.settings.rendererSynced.id_col];
@@ -509,18 +509,18 @@
             .rollup(function(d) {
                 return d;
             })
-            .map(chart.parent.data.raw); //filtered_data?
+            .map(chart.parent.data.raw);
 
         // get all the cells
         var cells = chart.table.selectAll('tbody tr').selectAll('td:nth-child(2)');
 
         // Store the appropriate td cell within the first row of for each subject's nested data
-        Object.keys(newNest).map(function(objectKey, index) {
-            newNest[objectKey][0].cell = cells[index][0];
+        Object.keys(idDict).map(function(objectKey, index) {
+            idDict[objectKey][0].cell = cells[index][0];
         });
 
         this.parent.data.sets.id_col.forEach(function(id) {
-            var id_data = newNest[id];
+            var id_data = idDict[id];
             var id_summary = d3
                 .nest()
                 .key(function(d) {
@@ -530,7 +530,7 @@
                     return d3.format('%')(d.length / id_data.length);
                 })
                 .entries(id_data);
-            var id_cell = newNest[id][0].cell;
+            var id_cell = idDict[id][0].cell;
             d3.select(id_cell).attr(
                 'title',
                 id_summary
@@ -1239,6 +1239,7 @@
 
     function onDestroy() {}
 
+    //import onPreprocess from './onPreprocess';
     function listing() {
         //Define listing.
         this.listing = new webCharts.createTable(

--- a/src/listing/onDraw/addSummaries/participant.js
+++ b/src/listing/onDraw/addSummaries/participant.js
@@ -1,19 +1,29 @@
 export default function participant() {
+    // create dictionary of id columns
+    const chart = this;
+    const newNest = d3
+        .nest()
+        .key(d => d[chart.parent.settings.rendererSynced.id_col])
+        .rollup(d => d)
+        .map(chart.parent.data.raw); //filtered_data?
+
+    // get all the cells
+    const cells = chart.table.selectAll('tbody tr').selectAll('td:nth-child(2)');
+
+    // Store the appropriate td cell within the first row of for each subject's nested data
+    Object.keys(newNest).map(function(objectKey, index) {
+        newNest[objectKey][0].cell = cells[index][0];
+    });
+
     this.parent.data.sets.id_col.forEach(id => {
-        const id_data = this.parent.data.raw.filter(
-            d => d[this.parent.settings.rendererSynced.id_col] === id
-        );
+        const id_data = newNest[id];
         const id_summary = d3
             .nest()
             .key(d => d[this.parent.settings.rendererSynced.visit_status_col])
             .rollup(d => d3.format('%')(d.length / id_data.length))
             .entries(id_data);
-        const id_cell = this.table
-            .selectAll('tbody tr')
-            .selectAll('td:nth-child(2)')
-            .filter(d => d.text.indexOf(id) > -1) // define a more rigid selector here
-            .filter((d, i) => i === 0);
-        id_cell.attr(
+        const id_cell = newNest[id][0].cell;
+        d3.select(id_cell).attr(
             'title',
             id_summary.map(status => `${status.key} (${status.values})`).join('\n')
         );

--- a/src/listing/onDraw/addSummaries/participant.js
+++ b/src/listing/onDraw/addSummaries/participant.js
@@ -1,28 +1,28 @@
 export default function participant() {
     // create dictionary of id columns
     const chart = this;
-    const newNest = d3
+    const idDict = d3
         .nest()
         .key(d => d[chart.parent.settings.rendererSynced.id_col])
         .rollup(d => d)
-        .map(chart.parent.data.raw); //filtered_data?
+        .map(chart.parent.data.raw);
 
     // get all the cells
     const cells = chart.table.selectAll('tbody tr').selectAll('td:nth-child(2)');
 
     // Store the appropriate td cell within the first row of for each subject's nested data
-    Object.keys(newNest).map(function(objectKey, index) {
-        newNest[objectKey][0].cell = cells[index][0];
+    Object.keys(idDict).map(function(objectKey, index) {
+        idDict[objectKey][0].cell = cells[index][0];
     });
 
     this.parent.data.sets.id_col.forEach(id => {
-        const id_data = newNest[id];
+        const id_data = idDict[id];
         const id_summary = d3
             .nest()
             .key(d => d[this.parent.settings.rendererSynced.visit_status_col])
             .rollup(d => d3.format('%')(d.length / id_data.length))
             .entries(id_data);
-        const id_cell = newNest[id][0].cell;
+        const id_cell = idDict[id][0].cell;
         d3.select(id_cell).attr(
             'title',
             id_summary.map(status => `${status.key} (${status.values})`).join('\n')

--- a/src/listing/onDraw/addSummaries/participant.js
+++ b/src/listing/onDraw/addSummaries/participant.js
@@ -1,6 +1,7 @@
 export default function participant() {
-    // create dictionary of id columns
     const chart = this;
+
+    // create dictionary of id columns
     const idDict = d3
         .nest()
         .key(d => d[chart.parent.settings.rendererSynced.id_col])
@@ -10,20 +11,28 @@ export default function participant() {
     // get all the cells
     const cells = chart.table.selectAll('tbody tr').selectAll('td:nth-child(2)');
 
-    // Store the appropriate td cell within the first row of for each subject's nested data
-    Object.keys(idDict).map(function(objectKey, index) {
-        idDict[objectKey][0].cell = cells[index][0];
-    });
+    // create ditionary of table cells
+    const cellDict = d3
+        .nest()
+        .key(function(d) {
+            return d[0].__data__.text;
+        })
+        .rollup(d => d[0])
+        .map(cells);
 
-    this.parent.data.sets.id_col.forEach(id => {
+    // get ids
+    const id_cols = d3
+        .set(chart.data.filtered.map(d => d[chart.parent.settings.rendererSynced.id_col]))
+        .values();
+
+    id_cols.forEach(id => {
         const id_data = idDict[id];
         const id_summary = d3
             .nest()
             .key(d => d[this.parent.settings.rendererSynced.visit_status_col])
             .rollup(d => d3.format('%')(d.length / id_data.length))
             .entries(id_data);
-        const id_cell = idDict[id][0].cell;
-        d3.select(id_cell).attr(
+        d3.select(cellDict[id][0]).attr(
             'title',
             id_summary.map(status => `${status.key} (${status.values})`).join('\n')
         );

--- a/src/listing/onDraw/addSummaries/participant.js
+++ b/src/listing/onDraw/addSummaries/participant.js
@@ -1,28 +1,24 @@
 export default function participant() {
-    const chart = this;
-
     // create dictionary of id columns
     const idDict = d3
         .nest()
-        .key(d => d[chart.parent.settings.rendererSynced.id_col])
+        .key(d => d[this.parent.settings.rendererSynced.id_col])
         .rollup(d => d)
-        .map(chart.parent.data.raw);
+        .map(this.parent.data.raw);
 
     // get all the cells
-    const cells = chart.table.selectAll('tbody tr').selectAll('td:nth-child(2)');
+    const cells = this.table.selectAll('tbody tr').selectAll('td:nth-child(2)');
 
     // create ditionary of table cells
     const cellDict = d3
         .nest()
-        .key(function(d) {
-            return d[0].__data__.text;
-        })
+        .key(d => d[0].__data__.text)
         .rollup(d => d[0])
         .map(cells);
 
     // get ids
     const id_cols = d3
-        .set(chart.data.filtered.map(d => d[chart.parent.settings.rendererSynced.id_col]))
+        .set(this.data.filtered.map(d => d[this.parent.settings.rendererSynced.id_col]))
         .values();
 
     id_cols.forEach(id => {


### PR DESCRIPTION
# Issues 
#26

# Comments
Slowness was coming primarily from participant.js.
![listing_performance_1](https://user-images.githubusercontent.com/26064686/45900280-d472b500-bdce-11e8-8551-f8a1c27ae9f2.JPG)

Worked on participant.js and that piece is a lot faster now (>7000 to <100 millisecs w/ the dev project 320 csv)


Now that the main problem is gone we are seeing the reflow problems we saw in crf heat map:
![listing_performance_2](https://user-images.githubusercontent.com/26064686/45900973-d6d60e80-bdd0-11e8-9070-83821c141ff0.JPG)

So the webcharts update should help with that.

I imagine there are other places to get more speed too (e.g. addcellFormatting), but this gets the low hanging fruit. 





